### PR TITLE
Add support for webpack's `require.resolve()`

### DIFF
--- a/register.js
+++ b/register.js
@@ -1,44 +1,43 @@
-function context(
-	basedir,
-	directory,
-	useSubdirectories = false,
-	regExp = /^\.\//
-) {
-	const path = require('path');
-	const fs = require('fs');
+function context(basedir, directory, useSubdirectories = false, regExp = /^\.\//) {
+  const path = require('path');
+  const fs = require('fs');
 
-	function enumerateFiles(basedir, dir) {
-		let result = [];
-		fs.readdirSync(path.join(basedir, dir)).forEach(function(file) {
-			const relativePath = dir + '/' + file;
-			const stats = fs.lstatSync(path.join(basedir, relativePath));
-			if (stats.isDirectory()) {
-				if (useSubdirectories) {
-					result = result.concat(enumerateFiles(basedir, relativePath));
-				}
-			} else if (regExp.test(relativePath)) {
-				result.push(relativePath);
-			}
-		});
-		return result;
-	}
+  function enumerateFiles(basedir, dir) {
+    let result = [];
+    fs.readdirSync(path.join(basedir, dir)).forEach(function (file) {
+      const relativePath = dir + '/' + file;
+      const stats = fs.lstatSync(path.join(basedir, relativePath));
+      if (stats.isDirectory()) {
+        if (useSubdirectories) {
+          result = result.concat(enumerateFiles(basedir, relativePath));
+        }
+      } else if (regExp.test(relativePath)) {
+        result.push(relativePath);
+      }
+    });
+    return result;
+  }
 
-	const absoluteDirectory = path.resolve(basedir, directory);
-	const keys = enumerateFiles(absoluteDirectory, '.');
+  const absoluteDirectory = path.resolve(basedir, directory);
+  const keys = enumerateFiles(absoluteDirectory, '.');
 
-	function requireContext(key) {
-		if (!keys.includes(key)) {
-			throw new Error(`Cannot find module '${key}'.`);
-		}
-		const fullKey = require('path').resolve(absoluteDirectory, key);
-		return require(fullKey);
-	}
+  function requireContext(key) {
+    if (!keys.includes(key)) {
+      throw new Error(`Cannot find module '${key}'.`);
+    }
+    const fullKey = require('path').resolve(absoluteDirectory, key);
+    return require(fullKey);
+  }
 
-	requireContext.keys = () => keys;
+  requireContext.keys = () => keys;
 
-	return requireContext;
+  // path.join() strips off a leading `./`, which webpack does not do
+  const prefix = directory.startsWith('./') ? './' : '';
+  requireContext.resolve = (filename) => prefix + path.join(directory, filename);
+
+  return requireContext;
 }
 
 module.exports = function register() {
-	global.__requireContext = context;
+  global.__requireContext = context;
 };

--- a/test/test.js
+++ b/test/test.js
@@ -1,15 +1,20 @@
 const assert = require('assert');
 
 const requireA = require.context('./a', false, /\.js$/);
+assert.deepEqual(requireA.keys(), ['./a.js']);
 assert.deepEqual(
-	requireA.keys().map(key => requireA(key)),
-	['a']
+  requireA.keys().map((key) => requireA(key)),
+  ['a']
 );
+assert.equal(requireA.resolve('./a.js'), './a/a.js');
 
 const requireAB = require.context('./a', true, /\.js$/);
+assert.deepEqual(requireAB.keys(), ['./a.js', './b/b.js']);
 assert.deepEqual(
-	requireAB.keys().map(key => requireAB(key)),
-	['a', 'b']
+  requireAB.keys().map((key) => requireAB(key)),
+  ['a', 'b']
 );
+assert.equal(requireA.resolve('./a.js'), './a/a.js');
+assert.equal(requireA.resolve('./b/b.js'), './a/b/b.js');
 
 console.log('OK');


### PR DESCRIPTION
As used by Storybook in https://github.com/storybookjs/storybook/blob/68b3ef639c044facf48eba759750e16315ae2a20/lib/core-client/src/preview/executeLoadable.ts#L28